### PR TITLE
Run lex_node via launch file 

### DIFF
--- a/robot_ws/.rosinstall
+++ b/robot_ws/.rosinstall
@@ -1,5 +1,5 @@
 # Amazon ROS CloudServiceIntegration package dependencies
 - git: {local-name: src/deps/utils-common, uri: 'https://github.com/aws-robotics/utils-common', version: v1.0.0}
 - git: {local-name: src/deps/utils-ros1, uri: 'https://github.com/aws-robotics/utils-ros1', version: v1.0.0}
-- git: {local-name: src/deps/lex-ros1, uri: 'https://github.com/aws-robotics/lex-ros1', version: v1.0.0}
+- git: {local-name: src/deps/lex-ros1, uri: 'https://github.com/aws-robotics/lex-ros1', version: v1.1.0}
 - git: {local-name: src/deps/tts-ros1, uri: 'https://github.com/aws-robotics/tts-ros1', version: v1.0.0}

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -18,11 +18,13 @@
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
+  <arg name="lex_node_name" value="lex_node"/>
   <include file="$(find lex_node)/launch/lex_node.launch">
     <arg name="config_file" value="$(find voice_interaction_robot)/config/lex_config.yaml"/>
+    <arg name="node_name" value="$(arg lex_node_name)"/>
     <arg name="output" value="$(arg output)"/>
   </include>
-  <rosparam if="$(eval aws_region != '')" param="lex_node/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam if="$(eval aws_region != '')" param="/$(arg lex_node_name)/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
 
   <!-- Launch Polly if enabled -->
   <arg name="use_polly" default="false"/>

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -11,12 +11,16 @@
 
   <!-- Optional AWS region, if empty uses the config defaults -->
   <arg name="aws_region" value="$(optenv ROS_AWS_REGION)" doc="AWS region override, defaults to config .yaml if unset"/>
+  
+  <!-- Default ROS output location, set this to 'log' to write stdout to a log file instead of the screen -->
+  <arg name="output" default="screen" doc="ROS stdout output location"/>
 
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
   <include file="$(find lex_node)/launch/lex_node.launch">
     <arg name="config_file" value="$(find voice_interaction_robot)/config/lex_config.yaml"/>
+    <arg name="output" value="$(arg output)"/>
   </include>
   <rosparam if="$(eval aws_region != '')" param="lex_node/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
 
@@ -28,15 +32,15 @@
 
   <remap from="/voice_interaction_node/text_output" to="/text_output" />
   <remap from="/voice_interaction_node/audio_output" to="/audio_output" />
-  <node pkg="voice_interaction_robot" type="voice_interaction" name="voice_interaction" output="screen"/>
+  <node pkg="voice_interaction_robot" type="voice_interaction" name="voice_interaction" output="$(arg output)"/>
 
   <arg name="use_microphone" default="false"/>
   <group if="$(arg use_microphone)">
     <remap from="/voice_input_node/audio_input" to="/audio_input" />
-    <node pkg="voice_interaction_robot" type="voice_input" name="voice_input" output="screen"/>
+    <node pkg="voice_interaction_robot" type="voice_input" name="voice_input" output="$(arg output)"/>
   </group>
 
-  <node pkg="voice_interaction_robot" type="voice_command_translator" name="voice_command_translator" output="screen"/>
-  <node pkg="voice_interaction_robot" type="voice_output" name="voice_output" output="screen"/>
-  <node pkg="voice_interaction_robot" type="audio_output" name="audio_output" output="screen"/>
+  <node pkg="voice_interaction_robot" type="voice_command_translator" name="voice_command_translator" output="$(arg output)"/>
+  <node pkg="voice_interaction_robot" type="voice_output" name="voice_output" output="$(arg output)"/>
+  <node pkg="voice_interaction_robot" type="audio_output" name="audio_output" output="$(arg output)"/>
 </launch>

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -15,10 +15,10 @@
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
-  <node name="lex_node" pkg="lex_node" type="lex_node" output="screen">
-    <rosparam command="load" file="$(find voice_interaction_robot)/config/lex_config.yaml"/>
-    <rosparam if="$(eval aws_region != '')" param="aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-  </node>
+  <include file="$(find lex_node)/launch/lex_node.launch">
+    <arg name="config_file" value="$(find voice_interaction_robot)/config/lex_config.yaml"/>
+  </include>
+  <rosparam if="$(eval aws_region != '')" param="lex_node/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
 
   <!-- Launch Polly if enabled -->
   <arg name="use_polly" default="false"/>


### PR DESCRIPTION
*Issue #, if available:* B9-2456

*Description of changes:*

- Run the lex_node via including it's launch file instead of running the node directly. This is the recommended way of using AWS Cloud Extensions. 
- Set the output location via a ROS arg and pass that arg into the voice_interaction launch file so that output goes to screen (the terminal) as it did previously. This requires merging https://github.com/aws-robotics/lex-ros1/pull/5 first. 

Tested running in RoboMaker IDE and ensured that the ROS_AWS_REGION overwrote the lex region correctly and when `output` was set it was sent to the correct location. 

After a new release of lex-ros1 is complete the `.rosinstall` file of this application needs to be updated with the latest tag before this PR is merged. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
