### PR TITLE
Add travis-wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 - git clone https://github.com/aws-robotics/travis-scripts.git .ros_ci
 script:
 - . .ros_ci/add_tag.sh
-- .ros_ci/ce_build.sh
+- travis_wait 50 .ros_ci/ce_build.sh
 before_deploy:
 - . .ros_ci/before_deploy.sh
 deploy:


### PR DESCRIPTION
The new colcon version sometimes doesn't display output for > 10 minutes. Adding travis_wait so the build continues even if this is the case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
