### PR TITLE
Allow passing user_id as launch parameter

### DIFF
--- a/robot_ws/src/voice_interaction_robot/launch/integration_test.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/integration_test.launch
@@ -1,10 +1,12 @@
 <launch>
+  <arg name="user_id" default="voice_interaction_example" doc="UserID used when communicating with the Lex Bot, can be any string"/>
   <include file="$(find voice_interaction_robot)/launch/voice_interaction.launch">
     <arg name="use_sim_time" value="true" />
     <arg name="use_polly" value="false" />
     <arg name="use_microphone" value="false" />
     <arg name="use_speaker" value="false" />
     <arg name="output" value="log"/>
+    <arg name="user_id" value="$(arg user_id)"/>
   </include>
   
   <node pkg="voice_interaction_robot" type="integration_test"  name="integration_test" output="screen" />

--- a/robot_ws/src/voice_interaction_robot/launch/integration_test.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/integration_test.launch
@@ -1,12 +1,10 @@
 <launch>
-  <arg name="user_id" value="$(optenv AWS_LEX_USER_ID voice_interaction_example)" doc="UserID used when communicating with the Lex Bot, can be any string"/>
   <include file="$(find voice_interaction_robot)/launch/voice_interaction.launch">
     <arg name="use_sim_time" value="true" />
     <arg name="use_polly" value="false" />
     <arg name="use_microphone" value="false" />
     <arg name="use_speaker" value="false" />
     <arg name="output" value="log"/>
-    <arg name="user_id" value="$(arg user_id)"/>
   </include>
   
   <node pkg="voice_interaction_robot" type="integration_test"  name="integration_test" output="screen" />

--- a/robot_ws/src/voice_interaction_robot/launch/integration_test.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/integration_test.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="user_id" default="voice_interaction_example" doc="UserID used when communicating with the Lex Bot, can be any string"/>
+  <arg name="user_id" value="$(optenv AWS_LEX_USER_ID voice_interaction_example)" doc="UserID used when communicating with the Lex Bot, can be any string"/>
   <include file="$(find voice_interaction_robot)/launch/voice_interaction.launch">
     <arg name="use_sim_time" value="true" />
     <arg name="use_polly" value="false" />

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -15,6 +15,9 @@
   <!-- Default ROS output location, set this to 'log' to write stdout to a log file instead of the screen -->
   <arg name="output" default="screen" doc="ROS stdout output location"/>
 
+  <!-- UserID sent when communicating with the Lex Bot, can be any string. Each robot talking to the same Lex Bot should have its own UserID -->
+  <arg name="user_id" default="voice_interaction_example" doc="UserID sent when communicating with the Lex Bot, can be any string"/>
+
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
 
@@ -25,6 +28,8 @@
     <arg name="output" value="$(arg output)"/>
   </include>
   <rosparam if="$(eval aws_region != '')" param="/$(arg lex_node_name)/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
+  <rosparam param="/$(arg lex_node_name)/lex_configuration/user_id" subst_value="true">$(arg user_id)</rosparam>
+
 
   <!-- Launch Polly if enabled -->
   <arg name="use_polly" default="false"/>

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -16,7 +16,7 @@
   <arg name="output" default="screen" doc="ROS stdout output location"/>
 
   <!-- UserID sent when communicating with the Lex Bot, can be any string. Each robot talking to the same Lex Bot should have its own UserID -->
-  <arg name="user_id" default="voice_interaction_example" doc="UserID sent when communicating with the Lex Bot, can be any string"/>
+  <arg name="user_id" value="$(optenv AWS_LEX_USER_ID)" doc="UserID sent when communicating with the Lex Bot, can be any string. Defauls to value in config .yaml if unset"/>
 
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>
@@ -28,7 +28,7 @@
     <arg name="output" value="$(arg output)"/>
   </include>
   <rosparam if="$(eval aws_region != '')" param="/$(arg lex_node_name)/aws_client_configuration/region" subst_value="true">$(arg aws_region)</rosparam>
-  <rosparam param="/$(arg lex_node_name)/lex_configuration/user_id" subst_value="true">$(arg user_id)</rosparam>
+  <rosparam if="$(eval user_id != '')" param="/$(arg lex_node_name)/lex_configuration/user_id" subst_value="true">$(arg user_id)</rosparam>
 
 
   <!-- Launch Polly if enabled -->


### PR DESCRIPTION
When running multiple robots at the same time connecting to the same LexBot you need a unique UserID for each. If Lex receives two commands at the same time from the same LexBot + UserID combination it
throws an error. So this allows specifying the UserID on launch.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

## Testing
- Tested running integration_test.launch and voice_interaction.launch with and without the parameter and using the AWS_LEX_USER_ID environment variable and it set the user_id correctly. 

