### PR TITLE
Change Lex UserID variable name, add README info.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Launch the application with the following commands:
     roslaunch voice_interaction_simulation bookstore.launch
     ```
 
+### Run Options
+
+You can set the following environment variables to configure your robot:
+
+- `ROS_AWS_REGION` - Set the AWS region of the Lex bot you are connecting to. Defaults to the value of `aws_client_configuration.region` in `config/lex_config.yaml` if unset. 
+- `LEX_USER_ID` - Set the UserID used when talking to the Lex bot. This is useful if you have multiple robots talking to the same Lex bot at the same time, as Lex will error if you send multiple commands using the same UserID to the same Lex bot at the same time. Defaults to the value of `lex_configuration.user_id` in `config/lex_config.yaml` if unset.  
+
 ## Test 
 
 First, run the robot following the commands in the "Run" section. Then try some of the possible ways to test below.

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -16,7 +16,7 @@
   <arg name="output" default="screen" doc="ROS stdout output location"/>
 
   <!-- UserID sent when communicating with the Lex Bot, can be any string. Each robot talking to the same Lex Bot should have its own UserID -->
-  <arg name="user_id" value="$(optenv AWS_LEX_USER_ID)" doc="UserID sent when communicating with the Lex Bot, can be any string. Defauls to value in config .yaml if unset"/>
+  <arg name="user_id" value="$(optenv LEX_USER_ID)" doc="UserID sent when communicating with the Lex Bot, can be any string. Defauls to value in config .yaml if unset"/>
 
   <arg name="use_sim_time" default="true"/>
   <param name="use_sim_time" value="$(arg use_sim_time)"/>


### PR DESCRIPTION
- RoboMaker simulation doesn't allow setting environment variables
starting with AWS_ so we have to change the variable name for this to
work correctly.
- Adding information to the readme about setting the userid.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
