### PR TITLE
Patching roboMakerSettings.json to be consistent with one-click launc…

### DIFF
--- a/roboMakerSettings.json
+++ b/roboMakerSettings.json
@@ -47,7 +47,7 @@
           },
           "launchConfig": {
             "packageName": "voice_interaction_robot",
-            "launchFile": "await_commands.launch"
+            "launchFile": "voice_interaction.launch"
           }
         },
         "simulationApp": {
@@ -57,9 +57,9 @@
           "architecture": "X86_64",
           "launchConfig": {
             "packageName": "voice_interaction_simulation",
-            "launchFile": "bookstore_turtlebot_navigation.launch",
+            "launchFile": "bookstore.launch",
             "environmentVariables":{
-               "TURTLEBOT3_MODEL":"burger"
+               "TURTLEBOT3_MODEL":"waffle_pi"
             }
           },
           "robotSoftwareSuite":{


### PR DESCRIPTION
…h settings.


*Description of changes:*

When customers checkout the voice-interaction sample app via the robomaker cloud9 IDE,
the provided settings.json file is subtly different than what is used during one-click launch.

The fix includes:
- type of turtle bot
- the simulation world
- and robot application launch file

*Issue #, if available:*

Fixes: https://github.com/aws-robotics/aws-robomaker-sample-application-voiceinteraction/issues/29


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
