### PR TITLE
Add lex_node, tts dependencies to package.xml

### DIFF
--- a/robot_ws/src/voice_interaction_robot/package.xml
+++ b/robot_ws/src/voice_interaction_robot/package.xml
@@ -24,6 +24,7 @@
   <depend>turtlebot3</depend>
   <depend>turtlebot3_msgs</depend>
   <depend>python-pyaudio</depend>
+  <depend>tts</depend>
   <build_depend>message_generation</build_depend>
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>

--- a/robot_ws/src/voice_interaction_robot/package.xml
+++ b/robot_ws/src/voice_interaction_robot/package.xml
@@ -29,4 +29,5 @@
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>turtlebot3_bringup</exec_depend>
   <exec_depend>python-rospkg</exec_depend>
+  <exec_depend>lex_node</exec_depend>
 </package>


### PR DESCRIPTION
Makes it possible to rely on `rosdep` without the need to `rosws update`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
