### PR TITLE
When not using polly, return text from Lex

### DIFF
--- a/roboMakerSettings.json
+++ b/roboMakerSettings.json
@@ -47,7 +47,7 @@
           },
           "launchConfig": {
             "packageName": "voice_interaction_robot",
-            "launchFile": "await_commands.launch"
+            "launchFile": "voice_interaction.launch"
           }
         },
         "simulationApp": {

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -39,7 +39,9 @@
 
   <remap from="/voice_interaction_node/text_output" to="/text_output" />
   <remap from="/voice_interaction_node/audio_output" to="/audio_output" />
-  <node pkg="voice_interaction_robot" type="voice_interaction" name="voice_interaction" output="$(arg output)"/>
+  <node pkg="voice_interaction_robot" type="voice_interaction" name="voice_interaction" output="$(arg output)">
+    <param name="use_polly" value="$(arg use_polly)">
+  </node>
   <node pkg="voice_interaction_robot" type="voice_command_translator" name="voice_command_translator" output="$(arg output)"/>
 
   <arg name="use_microphone" default="false"/>

--- a/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
+++ b/robot_ws/src/voice_interaction_robot/launch/voice_interaction.launch
@@ -40,7 +40,7 @@
   <remap from="/voice_interaction_node/text_output" to="/text_output" />
   <remap from="/voice_interaction_node/audio_output" to="/audio_output" />
   <node pkg="voice_interaction_robot" type="voice_interaction" name="voice_interaction" output="$(arg output)">
-    <param name="use_polly" value="$(arg use_polly)">
+    <param name="use_polly" type="bool" value="$(arg use_polly)"/>
   </node>
   <node pkg="voice_interaction_robot" type="voice_command_translator" name="voice_command_translator" output="$(arg output)"/>
 

--- a/robot_ws/src/voice_interaction_robot/nodes/voice_interaction
+++ b/robot_ws/src/voice_interaction_robot/nodes/voice_interaction
@@ -24,6 +24,7 @@ from audio_common_msgs.msg import AudioData
 from voice_interaction_robot_msgs.msg import FulfilledVoiceCommand
 
 lex_service = rospy.ServiceProxy("/lex_node/lex_conversation", AudioTextConversation)
+use_polly = rospy.get_param("/voice_interaction/use_polly")
 
 """
  This node does not respond to lex commands until it has been awoken
@@ -88,8 +89,11 @@ class VoiceInteraction:
             return None
 
         audio_data = request.data
+        accept_type = 'text/plain; charset=utf-8'
+        if use_polly:
+            accept_type = 'audio/pcm'
         lex_response = lex_service(content_type='audio/x-l16; sample-rate=16000; channel-count=1',
-                                   accept_type='audio/pcm',
+                                   accept_type=accept_type,
                                    text_request=None,
                                    audio_request=AudioData(data=audio_data))
         self.handle_lex_response(lex_response)


### PR DESCRIPTION
- When polly is disabled there's no need to return audio data from Lex.
So return text instead. This allows the application to run without the
lex service role.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
