### PR TITLE
Increase wait time for tests from 1s to 2s.

### DIFF
--- a/robot_ws/src/voice_interaction_robot/test/integration_test
+++ b/robot_ws/src/voice_interaction_robot/test/integration_test
@@ -94,15 +94,15 @@ class VoiceInteractionIntegrationTest:
     wake_words = ("jarvis", "turtlebot")
     last_cmd_vel = None
     vinode_start_timeout = 10
+    test_sleep_time = 2
     tests = []
     
-    def __init__(self, test_sleep_time=1):
+    def __init__(self):
         rospy.init_node("integration_test", disable_signals=True)
         self.text_input_publisher = rospy.Publisher("/text_input", String, queue_size=5)
         self.audio_input_publisher = rospy.Publisher("/audio_input", AudioData, queue_size=5)
         self.wake_publisher = rospy.Publisher("/wake_word", String, queue_size=5)
         rospy.Subscriber("/cmd_vel", Twist, self.save_cmd_vel)
-        self.test_sleep_time = test_sleep_time
         
     def run_tests(self):
         self.wait_for_voice_interaction_nodes()
@@ -175,6 +175,7 @@ class VoiceInteractionIntegrationTest:
         time.sleep(0.1)
         
     def save_cmd_vel(self, data):
+        rospy.logdebug("Received new cmd_vel: {}".format(data))
         self.last_cmd_vel = data
 
 def main():


### PR DESCRIPTION
Integration tests are failing on occasion because the message doesn't get to lex and back to the robot in <1s. Increasing this wait time to 2s and adding a debug log to better diagnose when the message is coming back from lex. 